### PR TITLE
Adding support for consecutive lambda code updates

### DIFF
--- a/lambda_bootstrap/main.tf
+++ b/lambda_bootstrap/main.tf
@@ -1,6 +1,11 @@
+data "aws_ecr_image" "lambda_image_latest" {
+  repository_name = split("/", var.ecr_repo_url)[1]
+  image_tag       = "latest"
+}
+
 resource "aws_iam_role" "iam_for_lambda" {
-    name = "${var.env_namespace}_lambda_role"
-    assume_role_policy = <<EOF
+  name               = "${var.env_namespace}_lambda_role"
+  assume_role_policy = <<EOF
 {
     "Version": "2012-10-17",
     "Statement": [
@@ -17,8 +22,8 @@ EOF
 }
 
 resource "aws_iam_role_policy" "iam_policy_for_lambda" {
-    role = aws_iam_role.iam_for_lambda.name
-    policy = <<POLICY
+  role   = aws_iam_role.iam_for_lambda.name
+  policy = <<POLICY
 {
   "Version": "2012-10-17",
   "Statement": [
@@ -45,8 +50,9 @@ resource "aws_iam_role_policy" "iam_policy_for_lambda" {
 POLICY
 }
 resource "aws_lambda_function" "main" {
-    function_name   = "${var.env_namespace}_lambda"
-    image_uri       = "${var.ecr_repo_url}:latest"
-    package_type    = "Image"
-    role            = aws_iam_role.iam_for_lambda.arn
+  function_name    = "${var.env_namespace}_lambda"
+  image_uri        = "${var.ecr_repo_url}:latest"
+  package_type     = "Image"
+  role             = aws_iam_role.iam_for_lambda.arn
+  source_code_hash = data.aws_ecr_image.lambda_image_latest.id
 }

--- a/lambda_bootstrap/providers.tf
+++ b/lambda_bootstrap/providers.tf
@@ -2,8 +2,7 @@ provider "aws" {
   region = "us-east-1"
 }
 
-terraform
-{
+terraform {
     backend "s3" {
       encrypt = true
       bucket = "BUCKET_NAME"

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -2,8 +2,7 @@ provider "aws" {
   region = "us-east-1"
 }
 
-terraform
-{
+terraform {
     backend "s3" {
       encrypt = true
       bucket = "BUCKET_NAME"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Fixed provider file errors which I came across while following the README.md steps. The minor in provider in nested lambda folder is needed to ensure the Deploy_docker stage in codepipeline does not fail.
Attaching a screenshot with this PR to show root cause of the failure:
<img width="1025" alt="image" src="https://user-images.githubusercontent.com/3850481/206031946-30bb2dca-3614-4cd1-9efc-868421d77833.png">
<img width="1085" alt="image" src="https://user-images.githubusercontent.com/3850481/206031969-a0ec2cb5-de1d-41ae-9b62-5cc595098617.png">


2. Added a intentional trigger for updating the lambda function based on source hash change. Since we are using the same tag:latest for all consecutive images which are getting build, currently any changes made to the lambda code would trigger a code pipeline run but when lambda is executed, without this PR change the old image is used to run as lambda resource in Terraform does not get updated.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
